### PR TITLE
Increment version number for Chrome store

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Better Better Destiny.gg",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "manifest_version": 2,
 
   "description": "Make Destiny.gg Great Again Again",


### PR DESCRIPTION
Chrome store wont let you update if the version number is the same in manifest.